### PR TITLE
Add various improvements to the original script

### DIFF
--- a/09-nvidia-blacklist.conf
+++ b/09-nvidia-blacklist.conf
@@ -1,0 +1,5 @@
+blacklist nvidia
+blacklist nvidia-drm
+blacklist nvidia-modeset
+blacklist nouveau
+options nvidia-drm modeset=1

--- a/README.md
+++ b/README.md
@@ -12,13 +12,102 @@ Installation/usage
 ------------------
 
 1. Run "prime-select nvidia" log out and login again, hopefully you are
-   using nvidia GPU. To switch back to intel GPU run "prime-select intel"
+   using nvidia GPU. To switch back to intel GPU run "prime-select intel" (modesetting driver) or 
+   "prime-select intel2" (Intel Open Source driver, requires xf86-video-intel package).
    Remember to run as root.
-2. To check which GPU you're currently using run "prime-select query".
+2. To check which GPU you're currently using run "prime-select get-current".
+3. In intel configurations, powering off the NVIDIA card with bbswitch to save power and decrease temperature is supported but requires additional manual setup. Refer to instructions below.
 
 Contact
 -------
 
 * Bo Simonsen <bo@geekworld.dk>
 * Michal Srb <msrb@suse.com>
+
+
+NVIDIA power off support
+-------------------------
+
+Powering off the NVIDIA card when not in use is very efficient for significantly decreasing power consumption (thus increase battery life) and temperature. However, this is complicated by the fact that the card can be powered off
+only when the NVIDIA kernel modules are not loaded.
+
+### Install bbswitch
+
+bbswitch is the kernel module that makes it possible to power off the NVIDIA card entirely.
+Install it with:
+
+```
+zypper in bbswitch
+```
+
+### Blacklist the nvidia modules so it can be loaded only when necessary
+
+The NVIDIA openSUSE package adds the NVIDIA driver modules to the kernel initrd image. This will make the system always load them on boot. This is problematic for disabling the NVIDIA card with bbswitch as it can only turn off the card when the modules are not loaded. Instead of unloading the modules before making use of bbswitch, the reverse is way easier: have the NVIDIA modules always unloaded and load them only when needed.
+To prevent the modules from being automatically loaded on boot, we need to blacklist them in initrd.
+This is easily done with:
+
+```
+cp /etc/prime/09-nvidia-blacklist.conf /etc/modprobe.d
+dracut -f
+```
+
+This will also blacklist the `nouveau` module which can really get in the way with Optimus and causing black screens.
+
+### Install the systemd service for loading NVIDIA module when needed
+
+```
+cp /etc/prime/better-prime-select.service /usr/lib/systemd/system
+systemctl enable better-prime-select
+```
+
+This service calls prime-select with whatever driver was previously set by user.
+If nvidia is set, it will load the NVIDIA modules before starting the Display Manager (login screen).
+Moreover, if an intel config is set but the Intel card was disabled in BIOS (leaving only the dGPU), this service will automatically switch to the nvidia config.
+
+
+## FAQ
+
+### What are the script parameters to select a driver ?
+
+better-prime-select `<driver>`
+
+Where `driver` is one of:
+
+- `intel`: uses the modesetting driver
+- `intel2`: uses the intel driver (xf86-video-intel). If you use Plasma you might get corrupted flickering display. To fix this make sure to disable vsync in the Plasma compositor settings first. Vsync will be handled by the intel driver
+- `nvidia`: use the NVIDIA binary driver
+
+
+### How do I switch from nvidia to intel with NVIDIA power off support ?
+
+
+It requires switching runlevels for the script to be able to remove the NVIDIA modules and power off the card:
+
+Exit Xorg, going into runlevel 3 (multi-user):
+
+```
+<save all your work in Xorg, close programs as needed>
+sudo init 3
+<login as root on console>
+```
+
+Use the script to change driver:
+
+```
+better-prime-select intel
+```
+
+Restart in run level 5 (graphical mode) with the new driver:
+
+```
+init 5
+```
+
+### How to I check that the NVIDIA card is powered off ?
+
+```
+cat /proc/acpi/bbswitch 
+0000:01:00.0 OFF
+```
+
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ This will also blacklist the `nouveau` module which can really get in the way wi
 ### Install the systemd service for loading NVIDIA module when needed
 
 ```
-cp /etc/prime/better-prime-select.service /usr/lib/systemd/system
-systemctl enable better-prime-select
+cp /etc/prime/prime-select.service /usr/lib/systemd/system
+systemctl enable prime-select
 ```
 
 This service calls prime-select with whatever driver was previously set by user.
@@ -69,7 +69,7 @@ Moreover, if an intel config is set but the Intel card was disabled in BIOS (lea
 
 ### What are the script parameters to select a driver ?
 
-better-prime-select `<driver>`
+prime-select `<driver>`
 
 Where `driver` is one of:
 
@@ -94,7 +94,7 @@ sudo init 3
 Use the script to change driver:
 
 ```
-better-prime-select intel
+prime-select intel
 ```
 
 Restart in run level 5 (graphical mode) with the new driver:

--- a/prime-select.service
+++ b/prime-select.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Prime Select Service
+Before=display-manager.service
+
+[Service]
+Type=oneshot
+ExecStart=prime-select apply-current
+
+[Install]
+WantedBy=graphical.target

--- a/prime-select.sh
+++ b/prime-select.sh
@@ -5,68 +5,173 @@
 
 # Public domain by Bo Simonsen <bo@geekworld.dk>
 # Adapted for OpenSUSE Tumbleweed by Michal Srb <msrb@suse.com>
-# Extended for TUXEDO Computers by Vinzenz Vietzke <vv@tuxedocomputers.com>
+# Augmented by bubbleguuum <bubbleguuum@free.fr>
 
 type=$1
-
 xorg_nvidia_conf="/etc/prime/xorg-nvidia.conf"
-xorg_intel_conf="/etc/prime/xorg-intel.conf"
+xorg_intel_conf_intel="/etc/prime/xorg-intel.conf"
+xorg_intel_conf_intel2="/etc/prime/xorg-intel-intel.conf"
+nvidia_modules="nvidia_drm nvidia_modeset nvidia_uvm nvidia"
+driver_choices="nvidia|intel|intel2"
+lspci_intel_line="VGA compatible controller: Intel"
+
+function usage {
+    echo
+    echo "usage: `basename $0` $driver_choices|unset|get-current|apply-current"
+    echo
+    echo "intel: use the Intel card with the modesetting driver"
+    echo "intel2: use the Intel card with the Intel open-source driver (xf86-video-intel). If you use this driver in a Plasma session, make sure to first disable vsync in the Plasma compositor settings to prevent video corruption"
+    echo "nvidia: use the NVIDIA binary driver"
+    echo "unset: disable effects of this script and let Xorg decide what driver to use"
+    echo "get-current: display driver currently in use by this tool"
+    echo "apply-current: re-apply this script using previously set driver (used by better-prime-select systemd service)"
+    echo
+}
+
+function check_root {
+    if (( $EUID != 0 )); then
+        echo "You must run this script as root"
+        exit 1
+    fi
+}
 
 function clean_files {
-      rm -f /etc/X11/xorg.conf.d/90-nvidia.conf
-      rm -f /etc/X11/xorg.conf.d/90-intel.conf
+    rm -f /etc/X11/xorg.conf.d/90-nvidia.conf
+    rm -f /etc/X11/xorg.conf.d/90-intel.conf
 }
 
 case $type in
-  nvidia)
-      if [[ $EUID -ne 0 ]]; then
-         echo "This script must be run with root permissions" 2>&1
-         exit 1
-      fi
+    
+    apply-current)
+	
+        if [ -f /etc/prime/current_type ]; then
+            
+            current_type=`cat /etc/prime/current_type`
+            
+            if [ "$current_type" != "nvidia"  ] && ! lspci | grep "$lspci_intel_line" > /dev/null; then
+                
+                # this can happen if user set intel but changed to "Discrete only" in BIOS
+                # in that case the Intel card is not visible to the system and we must switch to nvidia
+                
+                echo "Forcing nvidia due to Intel card not found"
+                current_type="nvidia"
+            fi
+            
+            $0 $current_type
+        fi
+        ;;
+    
+    nvidia)
 
-      clean_files 
+	check_root
+	
+	if [ -f /proc/acpi/bbswitch ]; then        
+            tee /proc/acpi/bbswitch > /dev/null <<EOF
+ON
+EOF
+	fi
 
-      gpu_info=`nvidia-xconfig --query-gpu-info`
-      # This may easily fail, if no NVIDIA kernel module is available or alike
-      if [ $? -ne 0 ]; then
-         echo "PCI BusID of NVIDIA card could not be detected!"
-         exit 1
-      fi
-      # There could be more than on NVIDIA card/GPU; use the first one in that case
-      nvidia_busid=`echo "$gpu_info" |grep -i "PCI BusID"|head -n 1|sed 's/PCI BusID ://'|sed 's/ //g'`
-      libglx_nvidia=`update-alternatives --list libglx.so|grep nvidia-libglx.so`
+	# will load all other dependency modules
+	modprobe nvidia_drm
+        
+	gpu_info=`nvidia-xconfig --query-gpu-info`
+	# This may easily fail, if no NVIDIA kernel module is available or alike
+	if [ $? -ne 0 ]; then
+            echo "PCI BusID of NVIDIA card could not be detected!"
+            exit 1
+	fi
+	
+	# There could be more than on NVIDIA card/GPU; use the first one in that case
 
-      update-alternatives --set libglx.so $libglx_nvidia
+	nvidia_busid=`echo "$gpu_info" |grep -i "PCI BusID"|head -n 1|sed 's/PCI BusID ://'|sed 's/ //g'`
 
-      cat $xorg_nvidia_conf | sed 's/PCI:X:X:X/'${nvidia_busid}'/' > /etc/X11/xorg.conf.d/90-nvidia.conf
-      echo "nvidia" > /etc/prime/current_type
-  ;;
-  intel)
-      if [[ $EUID -ne 0 ]]; then
-         echo "This script must be run with root permissions" 2>&1
-         exit 1
-      fi
+	libglx_nvidia=`update-alternatives --list libglx.so|grep nvidia-libglx.so`
 
-      clean_files
+	update-alternatives --set libglx.so $libglx_nvidia > /dev/null
 
-      libglx_xorg=`update-alternatives --list libglx.so|grep xorg-libglx.so`
+	clean_files
 
-      update-alternatives --set libglx.so $libglx_xorg
+	cat $xorg_nvidia_conf | sed 's/PCI:X:X:X/'${nvidia_busid}'/' > /etc/X11/xorg.conf.d/90-nvidia.conf
 
-      cp $xorg_intel_conf /etc/X11/xorg.conf.d/90-intel.conf
-      echo "intel" > /etc/prime/current_type
-  ;;
-  query)
-      if [ -f /etc/prime/current_type ]; then
-         echo -n "Currently running: "
-         cat /etc/prime/current_type
-      else
-         echo -n "Not configured yet! "
-         echo "Please use \"prime-select nvidia|intel\" for configuration."
-      fi
-  ;;
-  *)
-      echo "Usage: prime-select nvidia|intel|query"
-      exit
-  ;;
+	echo "$type" > /etc/prime/current_type     
+
+	$0 get-current
+	;;
+    
+    intel|intel2)
+
+	check_root
+	
+	if [ "$type" = "intel2" ]; then
+            if ! rpm -q xf86-video-intel > /dev/null; then
+		echo "package xf86-video-intel is not installed";
+		exit 1
+            fi
+            
+            conf=$xorg_intel_conf_intel2
+	else
+            # modesetting driver is part of xorg-x11-server and always available
+            conf=$xorg_intel_conf_intel
+	fi
+
+	# find Intel card bus id. Without this Xorg may fail to start
+	line=`lspci | grep "$lspci_intel_line" | head -1`
+	if [ $? -ne 0 ]; then
+            echo "Failed to find Intel card with lspci"
+            exit 1
+	fi
+
+	intel_busid=`echo $line | cut -f 1 -d ' ' | sed -e 's/\./:/g;s/:/ /g' | awk -Wposix '{printf("PCI:%d:%d:%d\n","0x" $1, "0x" $2, "0x" $3 )}'`
+	if [ $? -ne 0 ]; then
+            echo "Failed to build Intel card bus id"
+            exit 1
+	fi
+	
+	libglx_xorg=`update-alternatives --list libglx.so|grep xorg-libglx.so`
+
+	update-alternatives --set libglx.so $libglx_xorg > /dev/null     
+	
+	clean_files
+
+	cat $conf | sed 's/PCI:X:X:X/'${intel_busid}'/' > /etc/X11/xorg.conf.d/90-intel.conf
+
+	modprobe -r $nvidia_modules
+
+	if [ -f /proc/acpi/bbswitch ]; then        
+            tee /proc/acpi/bbswitch > /dev/null <<EOF 
+OFF
+EOF
+            grep OFF /proc/acpi/bbswitch > /dev/null || echo "Failed to power off NVIDIA card"
+
+	else
+            rpm -q bbswitch > /dev/null || echo "bbswitch is not installed. NVIDIA card will not be powered off"
+	fi
+	
+	echo "$type" > /etc/prime/current_type
+
+	$0 get-current
+	;;
+    
+    get-current)
+	
+	if [ -f /etc/prime/current_type ]; then
+            echo -n "Driver configured: "
+            cat /etc/prime/current_type
+      	else
+            echo "No driver configured."
+            echo "Use \"`basename $0` $driver_choices\" for configuration."
+	fi
+	;;
+
+    unset)
+
+	check_root
+	
+	clean_files
+	rm /etc/prime/current_type
+	;;
+
+    *)
+	usage
+	;;
 esac

--- a/prime-select.sh
+++ b/prime-select.sh
@@ -5,6 +5,7 @@
 
 # Public domain by Bo Simonsen <bo@geekworld.dk>
 # Adapted for OpenSUSE Tumbleweed by Michal Srb <msrb@suse.com>
+# Extended for TUXEDO Computers by Vinzenz Vietzke <vv@tuxedocomputers.com>
 # Augmented by bubbleguuum <bubbleguuum@free.fr>
 
 type=$1
@@ -24,7 +25,7 @@ function usage {
     echo "nvidia: use the NVIDIA binary driver"
     echo "unset: disable effects of this script and let Xorg decide what driver to use"
     echo "get-current: display driver currently in use by this tool"
-    echo "apply-current: re-apply this script using previously set driver (used by better-prime-select systemd service)"
+    echo "apply-current: re-apply this script using previously set driver (used by prime-select systemd service)"
     echo
 }
 

--- a/xorg-intel-intel.conf
+++ b/xorg-intel-intel.conf
@@ -5,7 +5,7 @@ EndSection
 
 Section "Device"
     Identifier "intel"
-    Driver "modesetting"
+    Driver "intel"
     BusID "PCI:X:X:X"
 EndSection
 

--- a/xorg-nvidia.conf
+++ b/xorg-nvidia.conf
@@ -1,28 +1,10 @@
-Section "ServerLayout"
-    Identifier "layout"
-    Screen 0 "nvidia"
-    Inactive "intel"
-EndSection
-
-Section "Device"
-    Identifier "intel"
-    Driver "modesetting"
-EndSection
-
-Section "Screen"
-    Identifier "intel"
-    Device "intel"
+Section "Module"
+    Load "modesetting"
 EndSection
 
 Section "Device"
     Identifier "nvidia"
     Driver "nvidia"
     BusID "PCI:X:X:X"
-    Option "DPI" "96 x 96"
-EndSection
-
-Section "Screen"
-    Identifier "nvidia"
-    Device "nvidia"
-    Option "AllowEmptyInitialConfiguration" "on"
+    Option "AllowEmptyInitialConfiguration"
 EndSection


### PR DESCRIPTION
1. add bbswitch support to power off NVIDIA card if not in use.
This is important to save battery when running on Intel and
to decrease cpu temperature significantly.
This support is optional, it requires user to make some
manual modifications to his system using detailed documentation.

2. add Intel Open Source driver support (xf86-video-intel)
via new intel2 command-line option.
This driver has some additional features that users may want.

3. add the proper BusID for Intel in xorg configuration.
Without this, Xorg fails to start on some laptops.

4. fix (via modified xorg-nvidia.conf) for external monitor
not enumerated by xrandr with the nvidia config.
On Optimus laptop, the dGPU is usually responsible of managing
external video ports, including connections via Thunderbolt 3.