### PR TITLE
SUSEPrime with some new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,68 @@ Assumptions
 * You don't have bumblebee installed
 * You installed nvidia drivers using http://opensuse-community.org/nvidia.ymp
 
-Installation/usage
-------------------
+DESCRIPTION:
 
-1. Run "prime-select nvidia" log out and login again, hopefully you are
-   using nvidia GPU. To switch back to intel GPU run "prime-select intel"
-   Remember to run as root.
-2. To check which GPU you're currently using run "prime-select query".
+What's suse-prime?
+SUSE-PRIME: a tool that lets you choose intel or nvidia card for X session in a Optimus technology laptop, performances are better than bumblebee. (https://github.com/openSUSE/SUSEPrime/)  (OLD https://github.com/michalsrb/SUSEPrime)
+
+My script provides: 
+
+>> Extended battery life and cooler temperatures, because suse-prime DO NOT put nvidia card in sleep mode when intel one is active. This feature is provided by Nouveau driver, without bumblebee or any ACPI Switch
+
+>> A choice to change default vga on boot, or remember the latest session
+
+REQUIREMENTS:
+
+Nvidia proprietary drivers: https://en.opensuse.org/SDB:NVIDIA_drivers
+
+USAGE:
+
+prime switch [intel | nvidia ]           >> [ROOT] system waits for logout to switch video card
+
+prime default [intel | nvidia | keep]    >> [ROOT] set default vga on boot (keep > remember latest session)
+
+prime query                              >> show current gpu and boot settings
+
+Tested on Optimus laptop with opensuse Tumbleweed and latest kernel (4.12 also works)
+suse-prime package not required, already included.
 
 Contact
 -------
 
 * Bo Simonsen <bo@geekworld.dk>
 * Michal Srb <msrb@suse.com>
+* simopil <pilia.simone96@gmail.com>
 
+File Paths
+
+RULES
+>> "optimus-switch.conf"      /etc/modprobe.d/    ||  modprobe rules for boot and modesetting
+        
+EXECUTABLES
+>> "prime"                 /usr/bin/           ||   executable tool, provides you all options
+ 
+CONFIG_FILES
+>> "config"              /etc/prime/         ||   main configuration file with all settings, DO NOT EDIT
+
+>> "xorg-intel.conf"     /etc/prime/         ||   suse-prime xorg config file of SUSEPrime project (michalsrb)
+
+>> "xorg-nvidia.conf"    /etc/prime/         ||   suse-prime xorg config file of SUSEPrime project (michalsrb)
+ 
+ 
+ 
+SERVICES
+ 
+>> "prime_logout.waiting"   /etc/prime/services/    ||   service that waits you logout to switch graphics
+
+>> "prime_switch"           /etc/prime/services/    ||   core of entire script
+ 
+>> "prime-select.sh"        /etc/prime/services/    ||   prime-select executable of SUSEPrime project (michalsrb)
+  
+
+
+SERVICES_CONFIG 
+
+>> "prime_logout.waiting.service"    /etc/systemd/system/     ||   service that waits you logout to switch graphics [CONFIG]
+
+>> "prime_switch.service"            /etc/systemd/system/     ||   core of entire script [CONFIG]

--- a/config
+++ b/config
@@ -1,0 +1,4 @@
+0
+L
+I
+#DON'T EDIT THIS FILE

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+function setup
+{
+    echo -e "\nPreparing to install ..."
+  
+    #File install
+    echo -e "\nCopying files ..."
+    mkdir                                         /etc/prime
+    mkdir                                         /etc/prime/services
+    cp config                                     /etc/prime/config
+    cp prime_switch                               /etc/prime/services/prime_switch
+    cp prime_logout.waiting                       /etc/prime/services/prime_logout.waiting
+    cp prime_switch.service                       /etc/systemd/system/prime_switch.service
+    cp prime_logout.waiting.service               /etc/systemd/system/prime_logout.waiting.service
+    cp prime                                      /usr/bin/prime
+    cp optimus-switch.conf                        /etc/modprobe.d/optimus-switch.conf
+    cp prime-select.sh                            /etc/prime/services/prime-select.sh
+    cp xorg-intel.conf                            /etc/prime/xorg-intel.conf
+    cp xorg-nvidia.conf                           /etc/prime/xorg-nvidia.conf
+    echo "Done."
+  
+    #Permissions
+    echo -e "\nSetting permissions ..."
+    chmod +x /etc/prime/services/prime_switch
+    chmod +x /etc/prime/services/prime_logout.waiting
+    chmod +x /etc/prime/services/prime-select.sh
+    chmod +x /usr/bin/vga
+    echo "Done."
+  
+    #Service
+    echo -e "\nSetting service ..."
+    systemctl enable prime_switch
+    bash /etc/prime/services/prime-select.sh intel
+    echo "Done."
+  
+    #Modprobe_rules
+    echo -e "\nSetting modprobe rules ..."
+    mkinitrd
+    echo "Done."
+    
+    echo -e "\nInstallation completed successfully! Please REBOOT and use [ prime ] command to know how to use\n"
+}
+
+echo
+if [[ $EUID > 0 ]]
+    then echo -e "Please run as root\n"
+    exit
+fi
+
+echo -e "Welcome to SUSEPrime installation! Based to original SUSEPrime and nvidia-optimus-switch project."
+echo -e "Please visit https://github.com/openSUSE/SUSEPrime"
+echo -e "\nPreliminary verification ..."
+
+if [ -x "$(command -v prime-select)" ]; then
+    echo -e "\nsuse-prime package not required, already included in this project! Uninstall it first" >&2
+    exit 1
+fi
+
+if [ -x "$(command -v optirun)" ]; then
+    echo -e "\nSeems you have bumblebee or similar installed, please remove it first!" >&2
+    exit 1
+fi
+
+echo
+read -p "SUSEPrime will be installed on your system, continue? (y|n): " confirm
+
+case "$confirm" in
+    y|Y ) setup;;
+    n|N ) echo -e "\nInstallation aborted\n";;
+      * ) echo -e "\nInvalid answer, installation aborted\n";;
+esac

--- a/optimus-switch.conf
+++ b/optimus-switch.conf
@@ -1,0 +1,6 @@
+options nvidia-drm modeset=1
+blacklist nvidia
+blacklist nvidia_drm
+blacklist nvidia_modeset
+blacklist nvidia_uvm
+blacklist nouveau

--- a/prime
+++ b/prime
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [[ $EUID > 0 ]]; then
+    if [[ $1 = "switch" ]] || [[ $1 = "default" ]]
+        then echo "Please run as root"
+        exit
+    fi
+fi
+
+current=$(sed -n '3p' /etc/prime/config)
+bootcard=$(sed -n '2p' /etc/prime/config)
+
+if [[ $1 = "switch" ]]; then
+    if [[ $2 = "intel" ]]; then
+        if [[ $current = "I" ]]; then
+            echo -e "\nIntel VGA already in use!!!\n"
+        else
+            echo -e "\nPlease logout to switch graphics\n"
+            sed -i '1 c2' /etc/prime/config
+            systemctl start prime_logout.waiting &
+        fi
+    elif [[ $2 = "nvidia" ]]; then
+        if [[ $current = "D" ]]; then
+            echo -e "\nNvidia VGA already in use!!!\n"
+        else
+            echo -e "\nPlease logout to switch graphics\n"
+            sed -i '1 c1' /etc/prime/config
+            systemctl start prime_logout.waiting &
+        fi      
+    else echo -e "\nUse: prime switch intel|nvidia\n"     
+    fi
+
+elif [[ $1 = "default" ]]; then
+    if [[ $2 = "intel" ]]; then
+        echo -e "\nBoot default: Intel\n"
+        sed -i '2 cI' /etc/prime/config
+    elif [[ $2 = "nvidia" ]]; then
+        echo -e "\nBoot default: Nvidia\n"
+        sed -i '2 cD' /etc/prime/config  
+    elif [[ $2 = "keep" ]]; then
+        sed -i '2 cL' /etc/prime/config   
+        echo -e "\nBoot default: Latest Session\n"
+    else echo -e "\nUse: prime default intel|nvidia|keep\n" 
+    fi
+
+elif [[ $1 = "query" ]]; then
+    echo -e
+    bash /etc/prime/services/prime-select.sh $1
+        case "$bootcard" in
+        I ) echo -e "\nDefault on boot: INTEL gpu\n";;
+        D ) echo -e "\nDefault on boot: NVIDIA gpu\n";;
+        L ) echo -e "\nDefault on boot: Last used\n";;
+    esac
+  
+else
+    echo -e "\nUSE: prime switch intel|nvidia         >    [ROOT] Hot Switch (logout required)\n"
+    echo -e "\n     prime default intel|nvidia|keep   >    [ROOT] Set default VGA on boot (keep > remember latest session)\n"
+    echo -e "\n     prime query                       >    Show current vga and boot settings"
+fi

--- a/prime_logout.waiting
+++ b/prime_logout.waiting
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while (( $(ps -p `pidof X` -o etimes=) > 3 )); do
+    sleep 1s
+done
+sleep 1s
+sudo systemctl isolate multi-user.target

--- a/prime_logout.waiting.service
+++ b/prime_logout.waiting.service
@@ -1,0 +1,13 @@
+# /etc/systemd/system/prime_logout.waiting.service
+#
+
+[Unit]
+Description=SUSEPrime user logout check service
+
+[Service]
+Type=forking
+ExecStart=/bin/bash -c "/etc/prime/services/prime_logout.waiting"
+ExecStop=
+
+[Install]
+WantedBy=graphical.target

--- a/prime_switch
+++ b/prime_switch
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if [[ $EUID > 0 ]]
+    then echo "Please run as root"
+    exit
+fi
+
+prime_select="/etc/prime/services/prime-select.sh"
+r3_execute=$(sed -n '1p' /etc/prime/config)
+boot_default=$(sed -n '2p' /etc/prime/config)
+last_session=$(sed -n '3p' /etc/prime/config)
+
+if [ $r3_execute = "1" ]; then
+    while [ `lsmod | grep -o ^nouveau` ]; do
+        rmmod nouveau
+        sleep 0.5s
+    done
+    sed -i '1 c0' /etc/prime/config
+    sed -i '3 cD' /etc/prime/config
+    modprobe nvidia &&  modprobe nvidia_drm &&  modprobe nvidia_modeset &&  modprobe nvidia_uvm
+    bash $prime_select nvidia
+    systemctl isolate graphical.target
+
+elif [ $r3_execute = "2" ]; then 
+    bash $prime_select intel
+    sed -i '1 c0' /etc/prime/config
+    sed -i '3 cI' /etc/prime/config
+    while [ `lsmod | grep -o ^'nvidia '` ]; do
+        rmmod nvidia_uvm
+        rmmod nvidia_drm
+        rmmod nvidia_modeset
+        rmmod nvidia
+        sleep 0.5s
+    done
+    modprobe nouveau 
+    systemctl isolate graphical.target
+
+elif [ $r3_execute = "0" ]; then
+    if [ $boot_default = "I" ]; then
+        modprobe nouveau
+        bash $prime_select intel
+        sed -i '3 cI' /etc/prime/config
+
+    elif [ $boot_default = "D" ]; then
+        sed -i '3 cD' /etc/prime/config
+        modprobe nvidia &&  modprobe nvidia_drm &&  modprobe nvidia_modeset &&  modprobe nvidia_uvm
+        bash $prime_select nvidia
+    
+    elif [ $boot_default = "L" ]; then
+        if [ $last_session = "I" ]; then
+            modprobe nouveau
+            bash $prime_select intel
+
+        elif [ $last_session = "D" ]; then
+            modprobe nvidia &&  modprobe nvidia_drm &&  modprobe nvidia_modeset &&  modprobe nvidia_uvm
+            bash $prime_select nvidia
+        fi
+    fi
+    sed -i '1 c0' /etc/prime/config
+    #nothing_to_do
+fi

--- a/prime_switch.service
+++ b/prime_switch.service
@@ -1,0 +1,14 @@
+# /etc/systemd/system/suse-prime.service
+#
+
+[Unit]
+Description=SUSEPrime switcher service
+After=multi-user.target
+
+[Service]
+Type=forking
+ExecStart=/bin/bash -c "/etc/prime/services/prime_switch"
+ExecStop=
+
+[Install]
+WantedBy=multi-user.target

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+function uninstall
+{
+    echo -e "\nPreparing to uninstall ..."
+
+    #Service
+    echo -e "\nDisabling service ..."
+    systemctl disable prime_switch
+    echo "Done."
+  
+    #File install
+    echo -e "\nRemoving files ..."
+    rm -r                           /etc/prime
+    rm                              /etc/systemd/system/prime_switch.service
+    rm                              /etc/systemd/system/prime_logout.waiting.service
+    rm                              /usr/bin/prime
+    rm                              /etc/modprobe.d/optimus-switch.conf
+    echo "Done."
+
+    #Modprobe_rules
+    echo -e "\nRestoring modprobe rules ..."
+    mkinitrd
+    echo "Done."
+    echo -e "\nScript uninstalled successfully!\n"
+}
+
+if [[ $EUID > 0 ]]
+    then echo -e "\nPlease run as root\n"
+    exit
+fi
+
+if [ ! -d /etc/prime/services ] ; then
+    echo -e "\nThis script is NOT installed, aborting ...\n"
+    exit
+fi
+
+echo
+read -p "Are you sure that you want to remove SUSEPrime from the system? (y|n): " confirm
+
+case "$confirm" in
+    y|Y ) uninstall;;
+    n|N ) echo -e "\nAborted\n";;
+      * ) echo -e "\nInvalid answer, aborted\n";;
+esac


### PR DESCRIPTION
Original project files, but uses command "prime" instead "prime-select".
Improvements:
-Default vga on boot, or remember last session (prime default intel|nvidia|keep)
-dGPU totally off with nouveau driver and NOT bumblebee, it's very old and sometimes causes issues
-query command shows boot gpu too

How does it works:
-Nouveau and Nvidia modules are both blacklisted in modprobe, at boot, if 1st parameter in "config" = 0, prime_switch load correct module according to user settings (prime default)
-When user do "prime switch .." a daemon called prime_logout.waiting starts and waits user logout from session, then, when xorg restarts, put in multi-user.target to swap modules, then put in graphical.target again.
-When user is under intel card, dGPU is off but with "DRI_PRIME=1" it's possible to use nvidia with Nouveau driver