### PR TITLE
New features adapted to bbswitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,17 @@ dracut -f
 
 This will also blacklist the `nouveau` module which can really get in the way with Optimus and causing black screens.
 
-### Install the systemd service for loading NVIDIA module when needed
+### Install the systemd services for doing switch and set correct card during boot
 
 ```
-cp /etc/prime/prime-select.service /usr/lib/systemd/system
-systemctl enable prime-select
+cp /etc/prime/prime-select.service           /usr/lib/systemd/system
+cp /etc/prime/prime-boot-selector.service    /usr/lib/systemd/system
+systemctl enable prime-boot-selector
 ```
 
-This service calls prime-select with whatever driver was previously set by user.
-If nvidia is set, it will load the NVIDIA modules before starting the Display Manager (login screen).
+Service prime-select chooses with whatever driver was previously set by user.
+Service prime-boot-selector sets all things during boot [MUST BE ENABLED]
+If nvidia is set, it will load the NVIDIA modules before starting the Graphical Target.
 Moreover, if an intel config is set but the Intel card was disabled in BIOS (leaving only the dGPU), this service will automatically switch to the nvidia config.
 
 
@@ -77,31 +79,6 @@ Where `driver` is one of:
 - `intel2`: uses the intel driver (xf86-video-intel). If you use Plasma you might get corrupted flickering display. To fix this make sure to disable vsync in the Plasma compositor settings first. Vsync will be handled by the intel driver
 - `nvidia`: use the NVIDIA binary driver
 
-
-### How do I switch from nvidia to intel with NVIDIA power off support ?
-
-
-It requires switching runlevels for the script to be able to remove the NVIDIA modules and power off the card:
-
-Exit Xorg, going into runlevel 3 (multi-user):
-
-```
-<save all your work in Xorg, close programs as needed>
-sudo init 3
-<login as root on console>
-```
-
-Use the script to change driver:
-
-```
-prime-select intel
-```
-
-Restart in run level 5 (graphical mode) with the new driver:
-
-```
-init 5
-```
 
 ### How to I check that the NVIDIA card is powered off ?
 

--- a/prime-boot-selector.service
+++ b/prime-boot-selector.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Prime Select Service
+Description=Prime Select Service (Boot Selector)
 After=multi-user.target
 Before=graphical.target
 
 [Service]
 Type=oneshot
-ExecStart=prime-select apply-current
+ExecStart=prime-select prime_booting
 
 [Install]
 WantedBy=multi-user.target

--- a/prime-boot-selector.service
+++ b/prime-boot-selector.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prime Select Service (Boot Selector)
 After=multi-user.target
-Before=graphical.target
+Before=display-manager.service
 
 [Service]
 Type=oneshot

--- a/prime-select.service
+++ b/prime-select.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prime Select Service
 After=multi-user.target
-Before=graphical.target
+Before=display-manager.service
 
 [Service]
 Type=oneshot

--- a/prime-select.sh
+++ b/prime-select.sh
@@ -175,7 +175,7 @@ function apply_current {
             
         if [ "$(cat /etc/prime/boot_state)" = "S" ]; then
             echo "N" > /etc/prime/boot_state
-            logging "setting boot_status to N, reenabling prime-boot-selector"
+            logging "Reenabling prime-boot-selector, setting boot_status to N"
             systemctl disable prime-select
             systemctl enable prime-boot-selector
             logging "Reaching graphical.target"
@@ -340,7 +340,7 @@ case $type in
 	
 	log-view)
 	
-        cat $prime_logfile
+        less +G -e $prime_logfile
 	;;
 	
 	log-clean)

--- a/prime-select.sh
+++ b/prime-select.sh
@@ -386,11 +386,7 @@ case $type in
             logging "prime-boot-selector: forcing booting with $(cat /etc/prime/current_type), boot preference ignored"
             logging "prime-boot-selector: setting-up $(cat /etc/prime/current_type) card"
             apply_current
-<<<<<<< HEAD
         else
-=======
-        elif [ -f /etc/prime/boot ]; then
->>>>>>> c7649c0... Little improvements
             boot_type=`cat /etc/prime/boot`
 	        if [ "$boot_type" != "last" ]; then
                 echo "$boot_type" > /etc/prime/current_type

--- a/prime-select.sh
+++ b/prime-select.sh
@@ -386,7 +386,11 @@ case $type in
             logging "prime-boot-selector: forcing booting with $(cat /etc/prime/current_type), boot preference ignored"
             logging "prime-boot-selector: setting-up $(cat /etc/prime/current_type) card"
             apply_current
+<<<<<<< HEAD
         else
+=======
+        elif [ -f /etc/prime/boot ]; then
+>>>>>>> c7649c0... Little improvements
             boot_type=`cat /etc/prime/boot`
 	        if [ "$boot_type" != "last" ]; then
                 echo "$boot_type" > /etc/prime/current_type

--- a/prime-select.sh
+++ b/prime-select.sh
@@ -251,8 +251,9 @@ case $type in
 	;;
 
 	user_logout_waiter)
-	#waits X process has an elapsed time < 3seconds, then jump init 3
-	while (( $(ps -p `pidof X` -o etimes=) > 3 )); do
+	#manage md5 sum xorg logs to check when X restarted, then jump init 3
+	logsum=$(md5sum /var/log/Xorg.0.log.old | awk '{print $1}')
+	while [ $logsum == $(md5sum /var/log/Xorg.0.log.old | awk '{print $1}') ]; do
     sleep 1s
     done
     systemctl enable prime-select &> /dev/null

--- a/prime-select.sh
+++ b/prime-select.sh
@@ -170,6 +170,7 @@ case $type in
     
     nvidia)
     
+    check_root
     echo "$type" > /etc/prime/current_type
     systemctl enable prime-select &> /dev/null
     systemctl disable prime-boot-selector &> /dev/null
@@ -179,6 +180,7 @@ case $type in
     
     intel)
     
+    check_root
     echo "$type" > /etc/prime/current_type
     systemctl enable prime-select &> /dev/null
     systemctl disable prime-boot-selector &> /dev/null
@@ -188,6 +190,7 @@ case $type in
     
     intel2)
     
+    check_root
     echo "$type" > /etc/prime/current_type
     systemctl enable prime-select &> /dev/null
     systemctl disable prime-boot-selector &> /dev/null
@@ -196,9 +199,10 @@ case $type in
 	;;
     
     boot)
-	    case $2 in
+        check_root
+	case $2 in
 	    
-	    nvidia|intel|intel2)
+            nvidia|intel|intel2)
 	    
 	    echo "$2" > /etc/prime/boot
 	    echo "Default at system boot: "


### PR DESCRIPTION
As promised, here an updated version with support to bbswitch.
Now command prime-select boot (nvidia | intel | intel2 | last) works and saves settings in /etc/prime/boot file, the prime-select service works in init 3 now, all target isolating operations are handled automatically by the script. This service must be set DISABLED, switch operation enables and disables it automatically.
User logout is checked by prime-select user_logout_waiting: it checks an X elapsed time < 3 to switch init 3
A new service called prime-boot-selector.service handles boot operations and do stuffs with bumblebee before graphical.target and must be set ENABLED, during hot switch this service will be disabled automatically by script.

To make a single bash script capable to do all operations, I separated switch functions from "$type case" , there are set_nvidia, set_intel and set_intel2