### PR TITLE
bbcheck function and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Contact
 * Bo Simonsen <bo@geekworld.dk>
 * Michal Srb <msrb@suse.com>
 
+Related projects
+----------------
+
+* SUSEPrimeQT <https://github.com/simopil/SUSEPrimeQt/> Provides a simple GUI for SUSEPrime
 
 NVIDIA power off support
 -------------------------


### PR DESCRIPTION
* New bbcheck function that has 4 returns:
   - "[bbswitch] NVIDIA card is OFF"
   - "[bbswitch] NVIDIA card is ON"
   - "bbswitch is installed but seems broken. Cannot change nvidia power status"
   - "bbswitch is not installed. NVIDIA card will not be powered off"
* Prevented execution of more than one "user_logout_waiter" istance
Minors:
* Replaced all logging interrogations of bbswitch and added it in "get-current" command
* Removed useless "check_root"s in set_intel/intel2/nvidia because user cannot execute them directly
* Added bbswitch issues check message in "prime-select driver" command
* Removed useless "logentry" variable in logging function
* Removed "get_current" at the end of set_intel/intel2/nvidia because there is logging and user cannot read directly