### PR TITLE
Add 30s timeout to service.

### DIFF
--- a/prime-select.service
+++ b/prime-select.service
@@ -5,6 +5,7 @@ Before=display-manager.service
 [Service]
 Type=oneshot
 ExecStart=prime-select systemd_call
+TimeoutSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
An issue in the current tumbleweed package is that it for some reason writes "undefined" to current_type, causing the service to hang forever.

This 30s timeout is just to ensure that user can boot even if the service fails.