### PR TITLE
Added option AllowExternalGpus to allow eGPUs by default

### DIFF
--- a/xorg-nvidia.conf
+++ b/xorg-nvidia.conf
@@ -36,4 +36,5 @@ Section "Device"
     BusID "PCI:X:X:X"
     Option "DPI" "96 x 96"
     Option "AllowEmptyInitialConfiguration"
+    Option "AllowExternalGpus"
 EndSection


### PR DESCRIPTION
When using an eGPU, Xorg will fail with:
```
[    25.206] (WW) NVIDIA(GPU-0): This device is an external GPU, but external GPUs have not
[    25.206] (WW) NVIDIA(GPU-0):     been enabled with AllowExternalGpus. Disabling this device
[    25.206] (WW) NVIDIA(GPU-0):     to prevent crashes from accidental removal.
[    26.781] (EE) NVIDIA(0): Failing initialization of X screen 0
[    26.781] (II) UnloadModule: "nvidia"
```
Adding `Option "AllowExternalGpus"` will enable eGPUs to work by default after `prime-select nvidia` if an eGPU is indeed plugged in.