### PR TITLE
Resolved bug "PCI BusID of NVIDIA card could not be detected!" error during boot

### DIFF
--- a/prime-select.sh
+++ b/prime-select.sh
@@ -224,8 +224,8 @@ function common_set_intel {
     gpu_info=$(nvidia-xconfig --query-gpu-info)
     # This may easily fail, if no NVIDIA kernel module is available or alike
     if [ $? -ne 0 ]; then
-        logging "PCI BusID of NVIDIA card could not be detected!"
-        exit 1
+        logging "PCI BusID of NVIDIA card could not be detected! If service seems to work correctly you can ignore this message."
+        #exit 1 removed because service fails at boot if nvidia card is default off with bbswitch
     fi
 
     # There could be more than on NVIDIA card/GPU; use the first one in that case
@@ -244,10 +244,10 @@ function common_set_intel {
 	modprobe -r $nvidia_modules
 
 	if [ -f /proc/acpi/bbswitch ]; then        
-            tee /proc/acpi/bbswitch > /dev/null <<EOF 
+           tee /proc/acpi/bbswitch > /dev/null <<EOF 
 OFF
 EOF
-    	fi
+    fi
 	
 	logging "trying switch OFF nvidia: $(bbcheck)"
 	

--- a/xorg-intel-intel.conf
+++ b/xorg-intel-intel.conf
@@ -24,13 +24,6 @@ Section "Device"
     BusID "PCI:X:X:X"
 EndSection
 
-# needed for NVIDIA PRIME Render Offload
-Section "Device"
-  Identifier "nvidia"
-  Driver "nvidia"
-  BusID "PCI:Y:Y:Y"
-EndSection
-
 Section "Screen"
     Identifier "intel"
     Device "intel"

--- a/xorg-intel.conf
+++ b/xorg-intel.conf
@@ -10,13 +10,6 @@ Section "Device"
     BusID "PCI:X:X:X"
 EndSection
 
-# needed for NVIDIA PRIME Render Offload
-Section "Device"
-  Identifier "nvidia"
-  Driver "nvidia"
-  BusID "PCI:Y:Y:Y"
-EndSection
-
 Section "Screen"
     Identifier "intel"
     Device "intel"

--- a/xorg-nvidia-prime-render-offload.conf
+++ b/xorg-nvidia-prime-render-offload.conf
@@ -1,0 +1,8 @@
+
+# needed for NVIDIA PRIME Render Offload
+Section "Device"
+  Identifier "nvidia"
+  Driver "nvidia"
+  BusID "PCI:Y:Y:Y"
+EndSection
+


### PR DESCRIPTION
Removed "exit 1" error from "common set intel" because during boot and nvidia card off by default in bbswitch (load_state=0) crashes service