### PR TITLE
Fix intel configs if no NVIDIA kernel module is available or alike

### DIFF
--- a/prime-select.sh
+++ b/prime-select.sh
@@ -13,6 +13,7 @@ type=$1
 xorg_nvidia_conf="/etc/prime/xorg-nvidia.conf"
 xorg_intel_conf_intel="/etc/prime/xorg-intel.conf"
 xorg_intel_conf_intel2="/etc/prime/xorg-intel-intel.conf"
+xorg_nvidia_prime_render_offload="/etc/prime/xorg-nvidia-prime-render-offload.conf"
 prime_logfile="/var/log/prime-select.log"
 nvidia_modules="nvidia_drm nvidia_modeset nvidia_uvm nvidia"
 driver_choices="nvidia|intel|intel2"
@@ -221,23 +222,27 @@ function common_set_intel {
         exit 1
     fi
 
-    gpu_info=$(nvidia-xconfig --query-gpu-info)
-    # This may easily fail, if no NVIDIA kernel module is available or alike
-    if [ $? -ne 0 ]; then
-        logging "PCI BusID of NVIDIA card could not be detected!"
-        exit 1
-    fi
-
-    # There could be more than on NVIDIA card/GPU; use the first one in that case
-    nvidia_busid=$(echo "$gpu_info" | grep -i "PCI BusID" | head -n 1 | sed 's/PCI BusID ://' | sed 's/ //g')
-
     libglx_xorg=$(update-alternatives --list libglx.so | grep xorg-libglx.so)
 
     update-alternatives --set libglx.so $libglx_xorg > /dev/null     
     
     clean_xorg_conf_d
 
-    cat $conf | sed -e 's/PCI:X:X:X/'${intel_busid}'/' -e 's/PCI:Y:Y:Y/'${nvidia_busid}'/' > /etc/X11/xorg.conf.d/90-intel.conf
+    cat $conf | sed -e 's/PCI:X:X:X/'${intel_busid}'/' > /etc/X11/xorg.conf.d/90-intel.conf
+
+    # extra snippet nvidia for NVIDIA's Prime Render Offload mode
+    gpu_info=$(nvidia-xconfig --query-gpu-info 2> /dev/null)
+
+    # This may easily fail, if no NVIDIA kernel module is available or alike
+    if [ $? -eq 0 -a "$gpu_info" != "" ]; then
+        # There could be more than on NVIDIA card/GPU; use the first one in that case
+        nvidia_busid=$(echo "$gpu_info" | grep -i "PCI BusID" | head -n 1 | sed 's/PCI BusID ://' | sed 's/ //g')
+        logging "Adding support for NVIDIA Prime Render Offload"
+        cat $xorg_nvidia_prime_render_offload | sed -e 's/PCI:Y:Y:Y/'${nvidia_busid}'/' >> /etc/X11/xorg.conf.d/90-intel.conf
+    else
+        logging "PCI BusID of NVIDIA card could not be detected!"
+        logging "NVIDIA Prime Render Offload not supported!"
+    fi
 
     if (( service_test == 0)); then
 

--- a/xorg-intel-intel.conf
+++ b/xorg-intel-intel.conf
@@ -24,13 +24,6 @@ Section "Device"
     BusID "PCI:X:X:X"
 EndSection
 
-# needed for NVIDIA PRIME Render Offload
-Section "Device"
-  Identifier "nvidia"
-  Driver "nvidia"
-  BusID "PCI:Y:Y:Y"
-EndSection
-
 Section "Screen"
     Identifier "intel"
     Device "intel"

--- a/xorg-intel.conf
+++ b/xorg-intel.conf
@@ -10,13 +10,6 @@ Section "Device"
     BusID "PCI:X:X:X"
 EndSection
 
-# needed for NVIDIA PRIME Render Offload
-Section "Device"
-  Identifier "nvidia"
-  Driver "nvidia"
-  BusID "PCI:Y:Y:Y"
-EndSection
-
 Section "Screen"
     Identifier "intel"
     Device "intel"

--- a/xorg-nvidia-prime-render-offload.conf
+++ b/xorg-nvidia-prime-render-offload.conf
@@ -1,0 +1,8 @@
+
+# needed for NVIDIA PRIME Render Offload
+Section "Device"
+  Identifier "nvidia"
+  Driver "nvidia"
+  BusID "PCI:Y:Y:Y"
+EndSection
+


### PR DESCRIPTION
Move additional nvidia X device section needed for NVIDIA's Prime
Render Offload mode to an extra xorg.conf.d snippet. Add this only
to intel X configs, if NVIDIA's PCI BusId can be detected.