### PR TITLE
Fix: use full path in invoking prime-select

### DIFF
--- a/prime-select.service
+++ b/prime-select.service
@@ -4,7 +4,7 @@ Before=display-manager.service
 
 [Service]
 Type=oneshot
-ExecStart=prime-select systemd_call
+ExecStart=/usr/sbin/prime-select systemd_call
 TimeoutSec=30
 
 [Install]


### PR DESCRIPTION
Use the full path when invoking `suse-prime` in the corresponding systemd service unit file.